### PR TITLE
(fix) Recast Str to Vec<u8> for rust-http changes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub mod mock {
         pub fn at_with<S: Str>(method: method::Method, path: Url, body: S) -> Request {
             Request {
                 url: path,
-                body: body.as_slice().to_string(),
+                body: body.as_slice().as_bytes().to_vec(),
                 method: method,
                 remote_addr: None,
                 headers: HeaderCollection::new(),


### PR DESCRIPTION
This is as a result of https://github.com/chris-morgan/rust-http/pull/164, which has already been accounted for in Iron.

It makes the test less robust (as it tests for Str, not Vec<u8>), but maintains the ergonomics that was already present.
IMO, a future PR should allow for testing of Vec<u8> outside of the current tests for Str, for the sake of ergonomics.