### PR TITLE
Required functions for NetworkStream trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,9 +18,10 @@ mod project_builder;
 /// Contains tooling for mocking various Iron objects.
 pub mod mock {
     use hyper::net::NetworkStream;
-    use std::net::SocketAddr;
-    use std::io::{Read, Write, Result};
     use std::any::Any;
+    use std::io::{Read, Write, Result};
+    use std::net::SocketAddr;
+    use std::time::Duration;
 
     /// A mock network stream
     #[derive(Clone)]
@@ -38,6 +39,14 @@ pub mod mock {
     impl<T: Send + Read + Write + Clone + Any> NetworkStream for MockStream<T> {
         fn peer_addr(&mut self) -> Result<SocketAddr> {
             Ok("127.0.0.1:3000".parse().unwrap())
+        }
+
+        fn set_read_timeout(&self, _: Option<Duration>) -> Result<()> {
+            Ok(())
+        }
+
+        fn set_write_timeout(&self, _: Option<Duration>) -> Result<()> {
+            Ok(())
         }
     }
 


### PR DESCRIPTION
Implement required functions for NetworkStream trait so that the library will compile.