### PR TITLE
Post Multipart Method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/reem/iron-test"
 license = "MIT"
 
 [dependencies]
+rand = "0.3"
 hyper = "0.7"
 iron = "0.2"
 log = "0.3"
@@ -18,3 +19,4 @@ uuid = "0.1"
 mime = "0.1"
 router = "0.0"
 urlencoded = "0.2"
+params = "0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,15 +8,14 @@ repository = "https://github.com/reem/iron-test"
 license = "MIT"
 
 [dependencies]
-rand = "0.3"
 hyper = "0.7"
 iron = "0.2"
 log = "0.3"
+rand = "0.3"
 url = "0.5"
 uuid = "0.1"
 
 [dev-dependencies]
 mime = "0.1"
-router = "0.0"
-urlencoded = "0.2"
 params = "0.0"
+router = "0.0"

--- a/README.md
+++ b/README.md
@@ -52,14 +52,47 @@ request::head<H: Handler>(path: &str, headers: Headers, handler: &H) -> IronResu
 request::post<H: Handler>(path: &str, headers: Headers, body: &str, handler: &H) -> IronResult<Response>
 request::patch<H: Handler>(path: &str, headers: Headers, body: &str, handler: &H) -> IronResult<Response>
 request::put<H: Handler>(path: &str, headers: Headers, body: &str, handler: &H) -> IronResult<Response>
+
+// Accepts a `MultipartBody` body
+request::post_multipart<H: Handler>(path: &str, mut headers: Headers, mut body: MultipartBody, handler: &H) -> IronResult<Response>
 ```
 
-The requests that it makes sense for accept a `&str` body, while the other
-requests generate an empty body for you. The request is passed directly to 
-the `handle` call on the Handler, and the raw result is returned to you.
+The generated request is passed directly to the `handle` call on the Handler,
+and the raw result is returned to you.
 
 For examples of testing different handlers, head over to the [examples
 directory](https://github.com/reem/iron-test/tree/master/examples).
+
+#### MultipartBody
+The MultipartBody struct is used to construct a multipart/form-data request,
+which is normally used for POSTing files to a web application. The API is as follows:
+
+```Rust
+impl MultipartBody {
+    // Initializes a new MultipartBody with a generated boundary.
+    pub fn new() -> MultipartBody
+
+    // Writes a key:value pair to an instance of a MultipartBody, is used for adding
+    // normal text key:values to a multipart request body.
+    pub fn write(&mut self, key: String, value: String)
+
+    // Writes a key:file pair to an instance of a MultipartBody, is used for adding
+    // a file's filename and contents to a multipart request body at a specific key.
+    pub fn upload(&mut self, key: String, path: PathBuf)
+}
+```
+
+### response
+The response API implements convenience methods for working with and testing
+Iron Responses. The current API contains two helpers:
+
+```Rust
+response::extract_body_to_bytes(response: Response) -> Vec<u8>
+response::extract_body_to_string(response: Response) -> String
+```
+
+Both extract methods take an Iron Response, read the body out to a new buffer,
+and return it to you in their respective forms.
 
 ### Creating project layout for tests
 

--- a/examples/body_test.rs
+++ b/examples/body_test.rs
@@ -1,23 +1,31 @@
 extern crate iron;
 extern crate iron_test;
 extern crate mime;
-extern crate urlencoded;
+extern crate params;
 
 use iron::{Handler, status};
 use iron::prelude::*;
-
-use urlencoded::UrlEncodedBody;
 
 struct BodyHandler;
 
 impl Handler for BodyHandler {
     fn handle(&self, req: &mut Request) -> IronResult<Response> {
-        let body = req.get_ref::<UrlEncodedBody>()
+        let params = req.get_ref::<params::Params>()
             .expect("Expected to extract a UrlEncodedBody from the request");
-        let first_name = body.get("first_name").unwrap()[0].to_owned();
-        let last_name = body.get("last_name").unwrap()[0].to_owned();
+        let first_name = get_params_value(params, "first_name");
+        let last_name = get_params_value(params, "last_name");
 
         Ok(Response::with((status::Ok, first_name + " " + &last_name)))
+    }
+}
+
+fn get_params_value<'a>(params: &params::Map, key: &'a str) -> String {
+    let value = params.get(key);
+
+    // destructure the Value enum to get the param value out
+    match value {
+        Some(&params::Value::String(ref string)) => string.clone(),
+        _ => String::new(),
     }
 }
 

--- a/examples/multipart_test.rs
+++ b/examples/multipart_test.rs
@@ -27,6 +27,10 @@ impl Handler for MultipartHandler {
     }
 }
 
+fn main() {
+    Iron::new(MultipartHandler).http("localhost:3000").unwrap();
+}
+
 #[cfg(test)]
 mod test {
     use iron::Headers;

--- a/examples/multipart_test.rs
+++ b/examples/multipart_test.rs
@@ -1,0 +1,73 @@
+extern crate iron;
+extern crate iron_test;
+extern crate params;
+
+use iron::{Handler, status};
+use iron::prelude::*;
+
+use params::Params;
+
+struct MultipartHandler;
+
+impl Handler for MultipartHandler {
+    fn handle(&self, req: &mut Request) -> IronResult<Response> {
+        let params = req.get_ref::<params::Params>()
+            .expect("Expected to extract Params from the request.");
+        let value = params.get("key");
+
+        match value {
+            Some(&params::Value::String(ref string)) => {
+                Ok(Response::with((status::Ok, string.to_owned())))
+            },
+            Some(&params::Value::File(ref file)) => {
+                Ok(Response::with((status::Ok, file.filename().unwrap())))
+            },
+            _ => Ok(Response::with(status::Ok)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use iron::Headers;
+
+    use iron_test::{request, response};
+
+    use std::fs::File;
+    use std::io::Write;
+    use std::path::PathBuf;
+
+    use super::MultipartHandler;
+
+    #[test]
+    fn test_post_key() {
+        let mut body = request::MultipartBody::new();
+        body.write("key".to_owned(), "my value".to_owned());
+
+        let response = request::post_multipart("http://localhost:3000/multipart",
+                                               Headers::new(),
+                                               body,
+                                               &MultipartHandler);
+        let result = response::extract_body_to_bytes(response.unwrap());
+
+        assert_eq!(result, b"my value");
+    }
+
+    #[test]
+    fn test_post_file() {
+        let mut body = request::MultipartBody::new();
+
+        let path = PathBuf::from("/tmp/file.txt");
+        let mut file = File::create(path.clone()).unwrap();
+        file.write_all(b"Hello, world!").ok();
+
+        body.upload("key".to_owned(), path);
+        let response = request::post_multipart("http://localhost:3000",
+                                               Headers::new(),
+                                               body,
+                                               &MultipartHandler);
+        let result = response::extract_body_to_string(response.unwrap());
+
+        assert_eq!(result, "file.txt");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ extern crate iron;
 extern crate hyper;
 extern crate url;
 extern crate uuid;
+extern crate rand;
 
 #[macro_use]
 extern crate log;

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -31,7 +31,9 @@ pub fn post<H: Handler>(path: &str, headers: Headers, body: &str, handler: &H) -
 /// request body.
 pub fn post_multipart<H: Handler>(path: &str, mut headers: Headers, mut body: MultipartBody, handler: &H) -> IronResult<Response> {
     let request_body = body.for_request();
-    headers.set(ContentType(Mime(TopLevel::Multipart, SubLevel::FormData, vec![(Attr::Boundary, Value::Ext(body.boundary))])));
+    headers.set(ContentType(Mime(TopLevel::Multipart,
+                                 SubLevel::FormData,
+                                 vec![(Attr::Boundary, Value::Ext(body.boundary))])));
     request(method::Post, path, request_body, headers, handler)
 }
 

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -99,7 +99,6 @@ pub fn request<H: Handler, B: AsRef<str>>(method: method::Method,
 mod test {
     extern crate params;
     extern crate router;
-    extern crate urlencoded;
 
     use iron::headers::Headers;
     use iron::mime::Mime;
@@ -113,9 +112,17 @@ mod test {
     use std::io::Write;
     use std::path::PathBuf;
 
-    use self::urlencoded::UrlEncodedBody;
-
     use super::*;
+
+    fn get_params_value<'a>(params: &params::Map, key: &'a str) -> String {
+        let value = params.get(key);
+
+        // destructure the Value enum to get the param value out
+        match value {
+            Some(&params::Value::String(ref string)) => string.clone(),
+            _ => String::new(),
+        }
+    }
 
     struct HelloWorldHandler;
 
@@ -142,10 +149,10 @@ mod test {
 
     impl Handler for PostHandler {
         fn handle(&self, req: &mut Request) -> IronResult<Response> {
-            let body = req.get_ref::<UrlEncodedBody>()
-                .expect("Expected to extract a UrlEncodedBody from the request");
-            let first_name = body.get("first_name").unwrap()[0].to_owned();
-            let last_name = body.get("last_name").unwrap()[0].to_owned();
+            let params = req.get_ref::<params::Params>()
+                .expect("Expected to extract Params from the request");
+            let first_name = get_params_value(params, "first_name");
+            let last_name = get_params_value(params, "last_name");
 
             Ok(Response::with((status::Ok, first_name + " " + &last_name)))
         }
@@ -162,10 +169,10 @@ mod test {
                 params.find("id").unwrap().parse::<String>().unwrap()
             };
 
-            let body = req.get_ref::<UrlEncodedBody>()
-                .expect("Expected to extract a UrlEncodedBody from the request");
-            let first_name = body.get("first_name").unwrap()[0].to_owned();
-            let last_name = body.get("last_name").unwrap()[0].to_owned();
+            let params = req.get_ref::<params::Params>()
+                .expect("Expected to extract Params from the request");
+            let first_name = get_params_value(params, "first_name");
+            let last_name = get_params_value(params, "last_name");
 
             Ok(Response::with((status::Ok, [first_name, last_name, id].join(" "))))
         }

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -103,7 +103,6 @@ mod test {
     extern crate router;
 
     use iron::headers::Headers;
-    use iron::mime::Mime;
     use iron::prelude::*;
     use iron::{Handler, headers, status};
 
@@ -251,8 +250,7 @@ mod test {
     #[test]
     fn test_post() {
         let mut headers = Headers::new();
-        let mime: Mime = "application/x-www-form-urlencoded".parse().unwrap();
-        headers.set(headers::ContentType(mime));
+        headers.set(headers::ContentType::form_url_encoded());
         let response = post("http://localhost:3000/users",
                             headers,
                             "first_name=Example&last_name=User",
@@ -268,8 +266,7 @@ mod test {
         router.patch("/users/:id", UpdateHandler);
 
         let mut headers = Headers::new();
-        let mime: Mime = "application/x-www-form-urlencoded".parse().unwrap();
-        headers.set(headers::ContentType(mime));
+        headers.set(headers::ContentType::form_url_encoded());
         let response = patch("http://localhost:3000/users/1",
                              headers,
                              "first_name=Example&last_name=User",
@@ -285,8 +282,7 @@ mod test {
         router.put("/users/:id", UpdateHandler);
 
         let mut headers = Headers::new();
-        let mime: Mime = "application/x-www-form-urlencoded".parse().unwrap();
-        headers.set(headers::ContentType(mime));
+        headers.set(headers::ContentType::form_url_encoded());
         let response = put("http://localhost:3000/users/2",
                            headers,
                            "first_name=Example&last_name=User",

--- a/src/request/multipart.rs
+++ b/src/request/multipart.rs
@@ -1,0 +1,164 @@
+use rand;
+use rand::Rng;
+
+use std::fs::File;
+use std::io::Read;
+use std::path::PathBuf;
+
+pub const BOUNDARY_LENGTH: usize = 32;
+
+/// A trait for describing the different types of entries that a multipart
+/// body can have, and implementing the functions needed to be able to write
+/// each kind of entry to the body.
+pub trait MultipartEntry {
+    /// A required method for MultipartEntry that returns the headers to write
+    /// to the multipart body.
+    fn headers(&self) -> String;
+
+    /// A required method for MultipartEntry that returns the value to write
+    /// to the multipart body.
+    fn value(&self) -> String;
+
+    /// A method that takes a boundary and the Entry's headers, and writes them
+    /// to a MultipartBody.
+    fn write_headers(&self, body: &mut MultipartBody) {
+        let boundary = body.full_boundary();
+        body.parts.push(boundary);
+        body.parts.push(self.headers());
+    }
+
+    /// A method that takes a boundary and the Entry's value, and writes them
+    /// to a MultipartBody.
+    fn write_value(&self, body: &mut MultipartBody) {
+        body.parts.push(self.value())
+    }
+}
+
+/// A struct representing a simple key:value pair in a multipart body.
+pub struct MultipartTextEntry {
+    key: String,
+    value: String,
+}
+
+impl MultipartEntry for MultipartTextEntry {
+    fn headers(&self) -> String {
+        "Content-Disposition: form-data; name=\"".to_owned() + &self.key + "\"\r\n"
+    }
+
+    fn value(&self) -> String {
+        self.value.clone()
+    }
+}
+
+/// A struct representing a key:file pair in a multipart body. Contains a `key`
+/// field representing the key that the file was uploaded at, and a `path` field
+/// representing where the file is on the file system.
+pub struct MultipartFileEntry {
+    key: String,
+    path: PathBuf,
+}
+
+impl MultipartEntry for MultipartFileEntry {
+    fn headers(&self) -> String {
+        let filename = self.path.file_name().unwrap();
+        "Content-Disposition: form-data; name=\"".to_owned() + &self.key + "\"; filename = \"" + filename.to_str().unwrap() + "\"\r\n"
+    }
+
+    fn value(&self) -> String {
+        let mut file_body = String::new();
+        let mut file = File::open(self.path.clone()).unwrap();
+        file.read_to_string(&mut file_body).ok();
+        file_body
+    }
+}
+
+/// A struct representing the parts of a Multipart request body. Contains a
+/// `boundary` field that is the raw generated boundary used to separate the
+/// request body, and a Vector of `parts`, that represent the different entries
+/// and boundaries in the request.
+pub struct MultipartBody {
+    /// A field holding the raw `boundary` separator used in the request body.
+    pub boundary: String,
+    parts: Vec<String>,
+}
+
+impl MultipartBody {
+    /// Initializes a new MultipartBody with a randomly generated `boundary`,
+    /// and an empty Vector of parts.
+    pub fn new() -> Self {
+        MultipartBody {
+            boundary: MultipartBody::generate_boundary(),
+            parts: Vec::new(),
+        }
+    }
+
+    /// Writes a key:value pair to the MultipartBody, pushing the appropriate
+    /// boundaries, headers, and value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use iron_test::request::MultipartBody;
+    ///
+    /// let mut body = MultipartBody::new();
+    /// body.write("key".to_owned(), "value".to_owned());
+    /// ```
+    ///
+    pub fn write(&mut self, key: String, value: String) {
+        let entry = MultipartTextEntry {
+            key: key,
+            value: value,
+        };
+
+        entry.write_headers(self);
+        entry.write_value(self);
+    }
+
+    /// 'Uploads' a key:file pair to the MultipartBody, pulling the file body
+    /// from the given path, and pushing the appropriate boundaries, headers,
+    /// and file body.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use iron_test::request::MultipartBody;
+    /// use std::fs::File;
+    /// use std::io::Write;
+    /// use std::path::PathBuf;
+    ///
+    /// let mut body = MultipartBody::new();
+    ///
+    /// let path = PathBuf::from("/tmp/file.txt");
+    /// let mut file = File::create(path.clone()).unwrap();
+    /// file.write_all(b"Hello, world!").ok();
+    ///
+    /// body.upload("key".to_owned(), path);
+    /// ```
+    ///
+    pub fn upload(&mut self, key: String, path: PathBuf) {
+        let entry = MultipartFileEntry {
+            key: key,
+            path: path,
+        };
+
+        entry.write_headers(self);
+        entry.write_value(self);
+    }
+
+    /// Builds the final body for use in an Iron::Request. Adds a closing
+    /// boundary to the parts Vector, and then joins everything on a newline.
+    pub fn for_request(&mut self) -> String {
+        let closing_boundary = self.full_boundary() + "--";
+        self.parts.push(closing_boundary);
+        self.parts.join("\r\n")
+    }
+
+
+    fn full_boundary(&self) -> String {
+        "--".to_owned() + &self.boundary.clone()
+    }
+
+    fn generate_boundary() -> String {
+        rand::thread_rng().gen_ascii_chars().take(BOUNDARY_LENGTH).collect()
+    }
+}


### PR DESCRIPTION
**New Features**

Implements a `request::post_multipart` convenience method for posting multipart/form-data requests. It uses a `MultipartBody` to let the user write values or upload files, and is eventually used to construct the request body.

**Tidied**

Replaced all direct uses of the `urlencoded` crate with the `params` crate, since we're now dealing with multiple request body types.

**Docs**

New examples entry for post_multipart, update the README with the new API, and also with the current response API.

**Notes**

I wanted to avoid writing my own multipart body generation, but https://github.com/cybergeek94/multipart makes the request from start to finish and I didn't see an easy way to hook into the request body generation to use for our purposes. https://github.com/mikedilger/formdata, the library that `params` uses for multipart body parsing, only implements the server side parsing, and not the client side generation.