### PR TITLE
Update hyper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/reem/iron-test"
 license = "MIT"
 
 [dependencies]
-hyper = "0.7"
+hyper = "0.8"
 iron = "0.2"
 log = "0.3"
 url = "0.5"


### PR DESCRIPTION
Currently `iron-test` has an incompatible version of `hyper` with `iron`. This PR upgrades `hyper` to avoid conflicts when using `iron-test` with `iron`.

```rust
error: mismatched types:
 expected `hyper::header::Headers`,
    found `hyper::header::Headers`
(expected struct `hyper::header::Headers`,
    found a different struct `hyper::header::Headers`) [E0308]
```

(with `iron` 0.3.0 and `iron-test` 0.2.0)