### PR TITLE
(chore) Upgrade to iron 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,13 @@ repository = "https://github.com/reem/iron-test"
 license = "MIT"
 
 [dependencies]
-hyper = "0.7"
-iron = "0.2"
+hyper = "0.8"
+iron = "0.3"
 log = "0.3"
 url = "0.5"
 uuid = "0.1"
 
 [dev-dependencies]
-mime = "0.1"
-router = "0.0"
-urlencoded = "0.2"
+mime = "0.2"
+router = "0.1"
+urlencoded = "0.3"


### PR DESCRIPTION
#30 requires some more work then I thought. Here's a more comprehensive upgrade to this crate and all of its dependencies. I ran into a bit of a snag, the development dependency `urlencoded` also needed an `iron` upgrade. `urlencoded`'s dependency `body-parser` also needed an upgrade and `body-parser`'s `persistent` also needed an upgrade. Below is a list of all the things which need to be done before we can merge this PR.

For all of these PRs, I'm using a git URL until we have an updated published version.

## Dependencies
- [x] Merge iron/persistent#52
- [x] Publish updated `persistent` version
- [x] Merge iron/body-parser#69
- [x] Publish updated `body-parser` version
- [x] Merge iron/urlencoded#62
- [x] Publish updated `urlencoded` version