### PR TITLE
Add 'ssl' feature to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,19 @@ description = "Mocking suite for Iron requests."
 repository = "https://github.com/reem/iron-test"
 license = "MIT"
 
+[features]
+default = []
+ssl = ["hyper/ssl"]
+
 [dependencies]
-hyper = "0.9"
 iron = "0.4"
 log = "0.3"
 url = "1.1"
 uuid = { version = "0.2", features = ["v4"] }
+
+[dependencies.hyper]
+version = "0.9"
+default-features = false
 
 [dev-dependencies]
 mime = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/reem/iron-test"
 license = "MIT"
 
 [features]
-default = []
+default = ["ssl"]
 ssl = ["hyper/ssl"]
 
 [dependencies]


### PR DESCRIPTION
This PR adds an "ssl" feature which allows hyper/ssl to be optionally enabled/disabled.
