### PR TITLE
Add feature for hyper/ssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/reem/iron-test"
 license = "MIT"
 
 [dependencies]
-hyper = "0.9"
+hyper = { version = "0.9", default-features = false }
 iron = "0.4"
 log = "0.3"
 url = "1.1"
@@ -18,3 +18,7 @@ uuid = { version = "0.2", features = ["v4"] }
 mime = "0.2"
 router = "0.2"
 urlencoded = "0.4"
+
+[features]
+default = []
+ssl = ["hyper/ssl"]


### PR DESCRIPTION
This is mimicking the [setup Iron has](https://github.com/iron/iron/blob/master/Cargo.toml). Unfortunately cargo unifies features between dependencies and dev-dependencies (https://github.com/rust-lang/cargo/issues/1796 and https://github.com/rust-lang/cargo/issues/2596). This means that currently, when using iron-test, it's not possible to use hyper without the ssl feature. This PR fixes that.