### PR TITLE
Support iron 0.5.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 
 name = "iron-test"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Jonathan Reem <jonathan.reem@gmail.com>"]
 description = "Mocking suite for Iron requests."
 repository = "https://github.com/reem/iron-test"
 license = "MIT"
 
 [dependencies]
-hyper = "0.9"
-iron = "0.4"
+hyper = "0.10"
+iron = "0.5"
 log = "0.3"
 url = "1.1"
 uuid = { version = "0.2", features = ["v4"] }
 
 [dev-dependencies]
 mime = "0.2"
-router = "0.2"
-urlencoded = "0.4"
+router = "0.5"
+urlencoded = "0.5"

--- a/examples/router_test.rs
+++ b/examples/router_test.rs
@@ -22,7 +22,7 @@ impl Handler for RouterHandler {
 
 fn app_router() -> Router {
     let mut router = Router::new();
-    router.get("/:id", RouterHandler);
+    router.get("/:id", RouterHandler, "router");
     router
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -10,10 +10,9 @@ pub fn extract_body_to_string(response: Response) -> String {
 pub fn extract_body_to_bytes(response: Response) -> Vec<u8> {
     let mut result = Vec::new();
 
-    match response.body {
-        Some(mut body) => body.write_body(&mut result).ok(),
-        None => None,
-    };
+    if let Some(mut body) = response.body {
+        body.write_body(&mut result).ok();
+    }
 
     result
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,5 +1,4 @@
 use iron::prelude::*;
-use iron::response::{ResponseBody};
 
 /// Extracts a utf8 response body to a String.
 pub fn extract_body_to_string(response: Response) -> String {
@@ -11,13 +10,10 @@ pub fn extract_body_to_string(response: Response) -> String {
 pub fn extract_body_to_bytes(response: Response) -> Vec<u8> {
     let mut result = Vec::new();
 
-    {
-        let mut response_body = ResponseBody::new(&mut result);
-        match response.body {
-            Some(mut body) => body.write_body(&mut response_body).ok(),
-            None => None,
-        };
-    }
+    match response.body {
+        Some(mut body) => body.write_body(&mut result).ok(),
+        None => None,
+    };
 
     result
 }


### PR DESCRIPTION
From iron 0.5.x, iron::Request includes a private field, so it is not
feasible to create iron::Request directly. So, we need to make
hyper::client::Request to make iron::Request.

hyper::client::Request also contains a private field. The public
interface to make it is to parse a http request.

So, in request.rs, we generate http request string, and pass it to
hyper::client::Request::new.